### PR TITLE
Fixed Hybrid Analysis hash search API request

### DIFF
--- a/hybrid-analysis/connector.py
+++ b/hybrid-analysis/connector.py
@@ -5,8 +5,13 @@ Copyright (c) 2024 Fortinet Inc
 Copyright end
 """
 
+"""
+HYBRID ANALYSIS
+"""
+
 from connectors.core.connector import Connector, get_logger, ConnectorError
-from .operations import check_health, hybrid_analysis_ops
+from .operations import check_health as ops_check_health, hybrid_analysis_ops
+from .constants import MACRO_LIST
 
 logger = get_logger('hybrid-analysis')
 
@@ -22,4 +27,34 @@ class Hybrid_Analysis(Connector):
         return result
 
     def check_health(self, config):
-        return check_health(config)
+        try:
+            logger.info('executing check health')
+            connection_response = ops_check_health(config)
+            return connection_response
+        except Exception as exp:
+            logger.exception(str(exp))
+            raise ConnectorError(str(exp))
+
+    def del_micro(self, config):
+        if not settings.LW_AGENT:
+            for macro in MACRO_LIST:
+                try:
+                    resp = make_request(f'/api/wf/api/dynamic-variable/?name={macro}', 'GET')
+                    if resp['hydra:member']:
+                        logger.info("resetting global variable '%s'" % macro)
+                        macro_id = resp['hydra:member'][0]['id']
+                        resp = make_request(f'/api/wf/api/dynamic-variable/{macro_id}/?format=json', 'DELETE')
+                except Exception as e:
+                    logger.error(e)
+
+    def on_deactivate(self, config):
+        self.del_micro(config)
+
+    def on_activate(self, config):
+        self.del_micro(config)
+
+    def on_add_config(self, config, active):
+        self.del_micro(config)
+
+    def on_delete_config(self, config):
+        self.del_micro(config)

--- a/hybrid-analysis/constants.py
+++ b/hybrid-analysis/constants.py
@@ -1,0 +1,2 @@
+MACRO_LIST = ["IP_Enrichment_Playbooks_IRIs", "URL_Enrichment_Playbooks_IRIs", "Domain_Enrichment_Playbooks_IRIs",
+              "FileHash_Enrichment_Playbooks_IRIs", "File_Enrichment_Playbooks_IRIs"]

--- a/hybrid-analysis/info.json
+++ b/hybrid-analysis/info.json
@@ -46,21 +46,21 @@
   "operations": [
     {
       "operation": "hashes_search",
-      "title": "Get Analysis Report for Multiple Hashcodes",
+      "title": "Get Analysis Report for Hashcode",
       "category": "investigation",
       "annotation": "get_analysis_report_for_multiple_hashcodes",
-      "description": "Retrieves the analysis report summary from the Hybrid Analysis server for multiple MD5/SHA1/SHA256 hash codes you have specified.",
+      "description": "Retrieves the analysis report summary from the Hybrid Analysis server for single MD5/SHA1/SHA256 hash code you have specified.",
       "parameters": [
         {
-          "title": "Hash Codes",
-          "name": "hashcodes",
+          "title": "Hash Code",
+          "name": "hashCode",
           "required": true,
           "editable": true,
           "visible": true,
           "type": "text",
-          "tooltip": "Either one md5/sha1/sha256 hash or several of them in CSV format",
-          "description": "Specify the hash codes in the MD5, SHA256, or SHA1 format whose summary you want to retrieve from the Hybrid Analysis server. You can specify multiple codes in the CSV format.",
-          "placeholder": "d41d8cd98f00b204e9800998ecf8427e,gwerfdc98f00b204e9810998ecf8427e"
+          "tooltip": "One md5/sha1/sha256 hash",
+          "description": "Specify the hash code in the MD5, SHA256, or SHA1 format whose summary you want to retrieve from the Hybrid Analysis server.",
+          "placeholder": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "enabled": true,

--- a/hybrid-analysis/operations.py
+++ b/hybrid-analysis/operations.py
@@ -357,11 +357,14 @@ def url_quick_scan(config, params):
 
 def hashes_search(config, params):
     try:
-        search_hashes_payload = {'hashes[]': str_to_list(params.get('hashcodes'))}
-        return _api_request("post", SEARCH_HASHES, config, payload=search_hashes_payload)
+        hash_value = params.get('hashCode')
+        hash_value = str(hash_value).strip()
+        search_hashes_params = {'hash': hash_value}
+        response = _api_request("get", SEARCH_HASHES, config, params=search_hashes_params)
+        return response
     except Exception as Err:
         logger.exception("Fail : {}".format(str(Err)))
-        raise ConnectorError(Err)
+        raise ConnectorError(str(Err))
 
 
 def handle_params(params):


### PR DESCRIPTION
Hi!

Since Hybrid Analysis has changed the hash search API endpoint we needed to fix it.
Change is written here:
https://hybrid-analysis.com/docs/api/v2#/Search/b972462c6d0d664b328b10b9e91da4c9
```
v2.36.0
Enhanced Quick Scan Results
Added vipre Quick Scan results to the scanners_v2 map in the FileCollectionQuickScan, UrlQuickScan, QuickScan, and Overview response classes.
v2.35.0
New Endpoints
Introduced new endpoint:
GET /search/hash which replaces the previous POST method for hash searches.
Deprecation Notice
The POST /search/hash endpoint is now marked as deprecated and will be removed in a future release. It has been replaced by GET /search/hash.
The /report/summary endpoint is now marked as deprecated and will be removed in a future release.
```

Changed the API request in `operations.py` to send correct data to Hybrid Analysis hash API endpoint and also changed the action config in `info.json`